### PR TITLE
refactor: use versioned API route for backend

### DIFF
--- a/Caddyfile-dev
+++ b/Caddyfile-dev
@@ -4,7 +4,7 @@
 }
 
 http://localhost {
-    handle_path /backend/* {
+    handle_path /backend/v1/* {
         reverse_proxy backend:8080
     }
     reverse_proxy frontend:3000

--- a/Caddyfile-example
+++ b/Caddyfile-example
@@ -1,6 +1,6 @@
 # vi: ft=caddyfile
 <hostname> {
-    handle_path /backend/* {
+    handle_path /backend/v1/* {
         reverse_proxy backend:8080
     }
     reverse_proxy frontend:5000


### PR DESCRIPTION
So my roomate's dad happened to overhear the end of our last meeting lol, and it turns out he works with APIs a lot, and one of the main things he suggested was having separate routes for each version of the API, so that if there's ever a major overhaul to the API, we can just leave `v1` running on the `/v1/` route, and start serving `v2` on a `/v2/` route.

He also had some other suggestions that I have to look into, but that's probably something for next meeting or the one after that.