### PR TITLE
fix: make production compose work

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -3,11 +3,12 @@ FROM gradle:jdk11 AS builder
 WORKDIR /usr/src/server
 COPY . .
 
-RUN gradle build
+RUN gradle shadowJar
+RUN mv build/libs/backend-*-all.jar build/libs/backend.jar
 
 FROM openjdk:11
 
 WORKDIR $JAVA_HOME/lib
-COPY --from=builder /usr/src/server/build/libs/backend-1.0-SNAPSHOT.jar ./backend.jar
+COPY --from=builder /usr/src/server/build/libs/backend.jar ./backend.jar
 
 ENTRYPOINT ["java", "-jar", "backend.jar"]

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -1,5 +1,7 @@
 FROM node:16
 
+ARG VITE_BACKEND_BASE_URL
+
 WORKDIR /usr/src/frontend
 COPY . .
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,8 +17,8 @@ services:
     build:
       context: ../frontend
       dockerfile: ../hosting/Dockerfile-frontend
-    environment:
-      VITE_BACKEND_BASE_URL: ${BACKEND_BASE_URL}
+      args:
+        VITE_BACKEND_BASE_URL: ${BACKEND_BASE_URL}
     networks:
       - proxy
     depends_on:


### PR DESCRIPTION
These changes fix the Docker-related files for production so that they work with our latest changes, including those in [backend #16](https://github.com/tli-group-4-grimm/backend/pull/16).