### PR TITLE
refactor: install pnpm before copying files

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -2,12 +2,12 @@ FROM node:16
 
 ARG VITE_BACKEND_BASE_URL
 
+RUN npm install -g pnpm
+
 WORKDIR /usr/src/frontend
 COPY . .
 
-RUN npm install -g pnpm
-RUN pnpm install
-RUN pnpm run build
+RUN pnpm install && pnpm run build
 
 EXPOSE 5000
 ENV HOST=0.0.0.0


### PR DESCRIPTION
This will speed up rebuilds of the container since the installation of pnpm can take place before the project files are coppied, so that intermediate installation can be cached.