### PR TITLE
fix: don't echo PID in backend dev entrypoint

### DIFF
--- a/Dockerfile-backend-dev
+++ b/Dockerfile-backend-dev
@@ -4,4 +4,4 @@ WORKDIR /usr/src/server
 RUN apt-get update && apt-get install -y --no-install-recommends inotify-tools=3.14-8 && rm -r /var/lib/apt/lists/*
 
 EXPOSE 8080
-ENTRYPOINT ["/bin/sh", "-c", "trap 'gradle --stop; exit' INT TERM; gradle test run & run_pid=\"$!\"; echo \"$run_pid\"; /bin/sh -c \"run_pid='$run_pid'; while inotifywait -r -e create,modify,moved_from,delete src; do kill \\\"\\$run_pid\\\"; gradle test run & run_pid=\\\"\\$!\\\"; done\" & while true; do tail -f /dev/null & wait $!; done"]
+ENTRYPOINT ["/bin/sh", "-c", "trap 'gradle --stop; exit' INT TERM; gradle test run & run_pid=\"$!\"; /bin/sh -c \"run_pid='$run_pid'; while inotifywait -r -e create,modify,moved_from,delete src; do kill \\\"\\$run_pid\\\"; gradle test run & run_pid=\\\"\\$!\\\"; done\" & while true; do tail -f /dev/null & wait $!; done"]


### PR DESCRIPTION
There was an unecessary echo that I forgot to remove after debugging in the backend dev container, this removes that.