### PR TITLE
fix: copy placeholder data to prod backend container

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -9,6 +9,8 @@ RUN mv build/libs/backend-*-all.jar build/libs/backend.jar
 FROM openjdk:11
 
 WORKDIR $JAVA_HOME/lib
+RUN mkdir data
 COPY --from=builder /usr/src/server/build/libs/backend.jar ./backend.jar
+COPY --from=builder /usr/src/server/data/cars.csv ./data/cars.csv
 
 ENTRYPOINT ["java", "-jar", "backend.jar"]


### PR DESCRIPTION
The way we're integrating our placeholder data for now requires that the csv file be present at the correct path, so this change makes sure it's copied there.