### PR TITLE
feat: add ansible playbooks, tasks, and github actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,26 @@
+name: Deploy with Ansible
+description: Deploys the project to the server
+on:
+  workflow_dispatch:
+    hosting_branch:
+      description: The branch to pull for the hosting repository
+      required: false
+      default: main
+    frontend_branch:
+      description: The branch to pull for the frontend repository
+      required: false
+      default: main
+    backend_branch:
+      description: The branch to pull for the backend repository
+      required: false
+      default: main
+  repository_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ansible
+        run: pip3 install ansible
+      - name: Deploy with ansible
+        run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/deploy.yaml

--- a/.github/workflows/restart.yaml
+++ b/.github/workflows/restart.yaml
@@ -1,0 +1,25 @@
+name: Restart with Ansible
+description: Deploys the project to the server
+on:
+  workflow_dispatch:
+    hosting_branch:
+      description: The branch to pull for the hosting repository
+      required: false
+      default: main
+    frontend_branch:
+      description: The branch to pull for the frontend repository
+      required: false
+      default: main
+    backend_branch:
+      description: The branch to pull for the backend repository
+      required: false
+      default: main
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ansible
+        run: pip3 install ansible
+      - name: Restart with ansible
+        run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/restart.yaml

--- a/.github/workflows/start.yaml
+++ b/.github/workflows/start.yaml
@@ -1,0 +1,25 @@
+name: Start with Ansible
+description: Deploys the project to the server
+on:
+  workflow_dispatch:
+    hosting_branch:
+      description: The branch to pull for the hosting repository
+      required: false
+      default: main
+    frontend_branch:
+      description: The branch to pull for the frontend repository
+      required: false
+      default: main
+    backend_branch:
+      description: The branch to pull for the backend repository
+      required: false
+      default: main
+jobs:
+  start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ansible
+        run: pip3 install ansible
+      - name: Start with ansible
+        run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/start.yaml

--- a/.github/workflows/stop.yaml
+++ b/.github/workflows/stop.yaml
@@ -1,0 +1,25 @@
+name: Stop with Ansible
+description: Deploys the project to the server
+on:
+  workflow_dispatch:
+    hosting_branch:
+      description: The branch to pull for the hosting repository
+      required: false
+      default: main
+    frontend_branch:
+      description: The branch to pull for the frontend repository
+      required: false
+      default: main
+    backend_branch:
+      description: The branch to pull for the backend repository
+      required: false
+      default: main
+jobs:
+  stop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ansible
+        run: pip3 install ansible
+      - name: Stop with ansible
+        run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/stop.yaml

--- a/Caddyfile-example
+++ b/Caddyfile-example
@@ -1,5 +1,5 @@
 # vi: ft=caddyfile
-<hostname> {
+<public_base_url> {
     handle_path /backend/v1/* {
         reverse_proxy backend:8080
     }

--- a/README.md
+++ b/README.md
@@ -18,11 +18,21 @@ docker-compose -f docker-compose-dev.yaml up
 cp Caddyfile-example Caddyfile
 ```
 
-Replace `<hostname>` in `Caddyfile` with the hostname of your server, for example: `http://localhost`
+Replace `<public_base_url>` in `Caddyfile` with the hostname of your server, for example: `https://example.com`
 
 ```sh
 docker-compose up
 ```
+
+### Ansible
+
+Create an inventory file, then run the following command to deploy the project to all hosts, make sure you specify the inventory:
+
+```sh
+ansible-playbook -i $INVENTORY playbooks/deploy.yaml
+```
+
+The playbooks `start`, `stop`, and `restart` can also be used to perform the actions their names suggest. Note that `restart` doesn't run `docker-compose restart`, it uses `stop` and then `start` to ensure that an updated compose file will be respected.
 
 ### Windows
 

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -1,0 +1,93 @@
+---
+- name: Deploy the project
+  hosts: all
+  vars:
+    public_base_url: '{{ lookup("env", "PUBLIC_BASE_URL") }}'
+    ansible_password: '{{ lookup("env", "SERVER_PASSWORD") }}'
+    frontend_branch: '{{ lookup("env", "FRONTEND_BRANCH") or "main" }}'
+    backend_branch: '{{ lookup("env", "BACKEND_BRANCH") or "main" }}'
+    hosting_branch: '{{ lookup("env", "HOSTING_BRANCH") or "main" }}'
+  tasks:
+    - name: Ensure the latest git is installed
+      package:
+        name: git
+        state: latest
+    - name: Ensure the latest Docker is installed
+      package:
+        name: docker
+        state: latest
+    - name: Ensure Docker is running
+      service:
+        name: docker
+        state: started
+        enabled: true
+    - name: Ensure the latest docker-compose is installed
+      package:
+        name: docker-compose
+        state: latest
+    - name: Clone/update hosting
+      git:
+        dest: ~/hosting
+        repo: https://github.com/tli-group-4-grimm/hosting
+        update: true
+      register: clone_hosting
+    - name: Checkout hosting branch
+      command:
+        chdir: ~/hosting
+        cmd: 'git checkout {{ hosting_branch }}'
+      register: checkout_hosting
+      changed_when: '"Already on " not in checkout_hosting.stderr'
+    - name: Clone/update frontend
+      git:
+        dest: ~/frontend
+        repo: https://github.com/tli-group-4-grimm/frontend
+        update: true
+      register: clone_frontend
+    - name: Checkout frontend branch
+      command:
+        chdir: ~/frontend
+        cmd: 'git checkout {{ frontend_branch }}'
+      register: checkout_frontend
+      changed_when: '"Already on " not in checkout_frontend.stderr'
+    - name: Clone/update backend
+      git:
+        dest: ~/backend
+        repo: https://github.com/tli-group-4-grimm/backend
+        update: true
+      register: clone_backend
+    - name: Checkout backend branch
+      command:
+        chdir: ~/backend
+        cmd: 'git checkout {{ backend_branch }}'
+      register: checkout_backend
+      changed_when: '"Already on " not in checkout_backend.stderr'
+    - name: Build frontend
+      command:
+        chdir: ~/hosting
+        cmd: docker-compose build frontend
+      when: clone_hosting.changed or checkout_hosting.changed or clone_frontend.changed or checkout_frontend.changed
+      register: build_frontend
+    - name: Build backend
+      command:
+        chdir: ~/hosting
+        cmd: docker-compose build backend
+      when: clone_hosting.changed or checkout_hosting.changed or clone_backend.changed or checkout_backend.changed
+      register: build_backend
+    - name: Copy Caddyfile-example to Caddyfile
+      copy:
+        src: ~/hosting/Caddyfile-example
+        dest: ~/hosting/Caddyfile
+        remote_src: true
+    - name: Replace public_base_url
+      replace:
+        path: ~/hosting/Caddyfile
+        regexp: "<public_base_url>"
+        replace: '{{ public_base_url }}'
+    - name: Check status
+      command:
+        cmd: docker-compose ls
+      register: compose_status
+      changed_when: false
+    - name: Restart compose
+      import_tasks: ../tasks/restart-compose.yaml
+      when: '"hosting" in compose_status and (build_frontend.changed or build_backend.changed)'

--- a/playbooks/restart.yaml
+++ b/playbooks/restart.yaml
@@ -1,0 +1,6 @@
+---
+- name: Restart deployment
+  hosts: all
+  tasks:
+    - name: Restart compose
+      import_tasks: ../tasks/restart-compose.yaml

--- a/playbooks/start.yaml
+++ b/playbooks/start.yaml
@@ -1,0 +1,6 @@
+---
+- name: Start deployment
+  hosts: all
+  tasks:
+    - name: Start compose
+      import_tasks: ../tasks/start-compose.yaml

--- a/playbooks/stop.yaml
+++ b/playbooks/stop.yaml
@@ -1,0 +1,6 @@
+---
+- name: Stop deployment
+  hosts: all
+  tasks:
+    - name: Stop compose
+      import_tasks: ../tasks/stop-compose.yaml

--- a/tasks/restart-compose.yaml
+++ b/tasks/restart-compose.yaml
@@ -1,0 +1,5 @@
+---
+- name: Stop compose
+  import_tasks: stop-compose.yaml
+- name: Start compose
+  include_tasks: start-compose.yaml

--- a/tasks/start-compose.yaml
+++ b/tasks/start-compose.yaml
@@ -1,0 +1,5 @@
+---
+- name: Start compose
+  command:
+    chdir: ~/hosting
+    cmd: docker-compose up -d --remove-orphans

--- a/tasks/stop-compose.yaml
+++ b/tasks/stop-compose.yaml
@@ -1,0 +1,5 @@
+---
+- name: Stop compose
+  command:
+    chdir: ~/hosting
+    cmd: docker-compose down


### PR DESCRIPTION
This pull request adds stuff for Ansible so we can set up actions that will deploy our project every time there are new updates. This will require the addition of some new actions on the other repositories. Also, I can't test these changes on branches that aren't main... so there will likely be fixes to follow :sweat_smile:.

This doesn't quite take care of #15 on it's own because we'll need to add workflows that trigger these from the other repos.