### PR TITLE
ci: fix missing `ansible_password` in other playbooks

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Ansible
         run: pip3 install ansible
-      - name: Deploy with ansible
+      - name: Deploy with Ansible
         run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/deploy.yaml
         env:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}

--- a/.github/workflows/restart.yaml
+++ b/.github/workflows/restart.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Ansible
         run: pip3 install ansible
-      - name: Restart with ansible
+      - name: Restart with Ansible
         run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/restart.yaml
         env:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}

--- a/.github/workflows/start.yaml
+++ b/.github/workflows/start.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Ansible
         run: pip3 install ansible
-      - name: Start with ansible
+      - name: Start with Ansible
         run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/start.yaml
         env:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}

--- a/.github/workflows/stop.yaml
+++ b/.github/workflows/stop.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Ansible
         run: pip3 install ansible
-      - name: Stop with ansible
+      - name: Stop with Ansible
         run: ansible-playbook -i "root@$SERVER_HOSTNAME", playbooks/stop.yaml
         env:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}

--- a/playbooks/restart.yaml
+++ b/playbooks/restart.yaml
@@ -1,6 +1,8 @@
 ---
 - name: Restart deployment
   hosts: all
+  vars:
+    ansible_password: '{{ lookup("env", "SERVER_PASSWORD") }}'
   tasks:
     - name: Restart compose
       import_tasks: ../tasks/restart-compose.yaml

--- a/playbooks/start.yaml
+++ b/playbooks/start.yaml
@@ -1,6 +1,8 @@
 ---
 - name: Start deployment
   hosts: all
+  vars:
+    ansible_password: '{{ lookup("env", "SERVER_PASSWORD") }}'
   tasks:
     - name: Start compose
       import_tasks: ../tasks/start-compose.yaml

--- a/playbooks/stop.yaml
+++ b/playbooks/stop.yaml
@@ -1,6 +1,8 @@
 ---
 - name: Stop deployment
   hosts: all
+  vars:
+    ansible_password: '{{ lookup("env", "SERVER_PASSWORD") }}'
   tasks:
     - name: Stop compose
       import_tasks: ../tasks/stop-compose.yaml


### PR DESCRIPTION
This PR fixes the capitalization of Ansible in the action steps, and adds the necessary `ansible_password` environment variable to the playbooks that were missing it.