### PR TITLE
fix: use include_tasks instead of import_tasks in restart tasks

### DIFF
--- a/tasks/restart-compose.yaml
+++ b/tasks/restart-compose.yaml
@@ -1,5 +1,5 @@
 ---
 - name: Stop compose
-  import_tasks: stop-compose.yaml
+  include_tasks: stop-compose.yaml
 - name: Start compose
   include_tasks: start-compose.yaml


### PR DESCRIPTION
Sorry, just cleaning up a small discrepancy in the earlier ansible PRs, I figured I should be consistent about which of the two I used.