### PR TITLE
fix: mount database files for persistence

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,8 @@ services:
     image: postgres:latest
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ../data:/var/lib/postgresql/data
     networks:
       - db
 


### PR DESCRIPTION
This PR mounts the folder inside the database docker container at `../data` so that data is persistent even if the database container is destroyed. This is only for the production compose file since it's unecessary for testing and development.