### PR TITLE
fix: disable host checking in workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,3 +28,4 @@ jobs:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}
           SERVER_HOSTNAME: ${{ secrets.SERVER_HOSTNAME }}
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+          ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/restart.yaml
+++ b/.github/workflows/restart.yaml
@@ -14,3 +14,4 @@ jobs:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}
           SERVER_HOSTNAME: ${{ secrets.SERVER_HOSTNAME }}
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+          ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/start.yaml
+++ b/.github/workflows/start.yaml
@@ -14,3 +14,4 @@ jobs:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}
           SERVER_HOSTNAME: ${{ secrets.SERVER_HOSTNAME }}
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+          ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/stop.yaml
+++ b/.github/workflows/stop.yaml
@@ -14,3 +14,4 @@ jobs:
           PUBLIC_BASE_URL: ${{ secrets.PUBLIC_BASE_URL }}
           SERVER_HOSTNAME: ${{ secrets.SERVER_HOSTNAME }}
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+          ANSIBLE_HOST_KEY_CHECKING: False


### PR DESCRIPTION
Recent workflows runs have been failing due to issues with host key checking, so this PR disables that.

This isn't a security issue, host key checking is designed to prevent you from connecting to a server that you think is yours, but actually someone else pretending to be your server, then entering sensitive information. This isn't really an issue for us though because all the commands and information the workflows run on the server are publicly visible.