### PR TITLE
fix: copy all data to production container

### DIFF
--- a/Dockerfile-backend
+++ b/Dockerfile-backend
@@ -11,6 +11,6 @@ FROM openjdk:11
 WORKDIR $JAVA_HOME/lib
 RUN mkdir data
 COPY --from=builder /usr/src/server/build/libs/backend.jar ./backend.jar
-COPY --from=builder /usr/src/server/data/cars.csv ./data/cars.csv
+COPY --from=builder /usr/src/server/data ./data
 
 ENTRYPOINT ["java", "-jar", "backend.jar"]


### PR DESCRIPTION
This pull request makes sure _all_ data is copied to the production backend container.